### PR TITLE
Initial support for SQL

### DIFF
--- a/immudb/client.py
+++ b/immudb/client.py
@@ -18,7 +18,7 @@ from immudb.handler import (batchGet, batchSet, changePassword, createUser,
                             currentRoot, databaseCreate, databaseList, databaseUse,
                             get, listUsers, verifiedGet, verifiedSet, setValue, history,
                             scan, reference, verifiedreference, zadd, verifiedzadd,
-                            zscan, healthcheck, txbyid, verifiedtxbyid)
+                            zscan, healthcheck, txbyid, verifiedtxbyid, sqlexec, sqlquery)
 from immudb.rootService import *
 from immudb.grpc import schema_pb2_grpc
 import warnings
@@ -218,3 +218,9 @@ class ImmudbClient:
 
     def verifiedTxById(self, tx: int):
         return verifiedtxbyid.call(self.__stub, self.__rs, tx, self.__vk)
+
+    def sqlExec(self, stmt, params={}, noWait=False):
+        return sqlexec.call(self.__stub, self.__rs, stmt, params, noWait)
+
+    def sqlQuery(self, query, params={}):
+        return sqlquery.call(self.__stub, self.__rs, query, params)

--- a/immudb/client.py
+++ b/immudb/client.py
@@ -221,10 +221,41 @@ class ImmudbClient:
         return verifiedtxbyid.call(self.__stub, self.__rs, tx, self.__vk)
 
     def sqlExec(self, stmt, params={}, noWait=False):
+        """Executes an SQL statement
+        Args:
+            stmt: a statement in immudb SQL dialect.
+            params: a dictionary of parameters to replace in the statement
+            noWait: whether to wait for indexing. Set to True for fast inserts.
+
+        Returns:
+            An object with two lists: ctxs and dtxs, including transaction
+            metadata for both the catalog and the data store.
+
+            Each element of both lists contains an object with the Transaction ID
+            (id), timestamp (ts), and number of entries (nentries).
+        """
+
         return sqlexec.call(self.__stub, self.__rs, stmt, params, noWait)
 
     def sqlQuery(self, query, params={}):
+        """Queries the database using SQL
+        Args:
+            query: a query in immudb SQL dialect.
+            params: a dictionary of parameters to replace in the query
+
+        Returns:
+            A list of table names. For example:
+
+            ['table1', 'table2']
+        """
         return sqlquery.call(self.__stub, self.__rs, query, params)
 
     def listTables(self):
+        """List all tables in the current database
+
+        Returns:
+            A list of table names. For example:
+
+            ['table1', 'table2']
+        """
         return listtables.call(self.__stub, self.__rs)

--- a/immudb/client.py
+++ b/immudb/client.py
@@ -18,7 +18,8 @@ from immudb.handler import (batchGet, batchSet, changePassword, createUser,
                             currentRoot, databaseCreate, databaseList, databaseUse,
                             get, listUsers, verifiedGet, verifiedSet, setValue, history,
                             scan, reference, verifiedreference, zadd, verifiedzadd,
-                            zscan, healthcheck, txbyid, verifiedtxbyid, sqlexec, sqlquery)
+                            zscan, healthcheck, txbyid, verifiedtxbyid, sqlexec, sqlquery,
+                            listtables)
 from immudb.rootService import *
 from immudb.grpc import schema_pb2_grpc
 import warnings
@@ -224,3 +225,6 @@ class ImmudbClient:
 
     def sqlQuery(self, query, params={}):
         return sqlquery.call(self.__stub, self.__rs, query, params)
+
+    def listTables(self):
+        return listtables.call(self.__stub, self.__rs)

--- a/immudb/handler/listtables.py
+++ b/immudb/handler/listtables.py
@@ -1,0 +1,28 @@
+# Copyright 2021 CodeNotary, Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#       http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+
+from immudb.grpc import schema_pb2
+from immudb.grpc import schema_pb2_grpc
+from immudb.rootService import RootService
+from immudb.typeconv import sqlvalue_to_py
+from immudb import datatypes
+from google.protobuf.empty_pb2 import Empty
+
+
+def call(service: schema_pb2_grpc.ImmuServiceStub, rs: RootService):
+    resp = service.ListTables(Empty())
+    result = []
+    for row in resp.rows:
+        result.append([sqlvalue_to_py(i) for i in row.values][0])
+    return result

--- a/immudb/handler/sqlexec.py
+++ b/immudb/handler/sqlexec.py
@@ -22,7 +22,8 @@ from immudb.typeconv import py_to_sqlvalue
 def call(service: schema_pb2_grpc.ImmuServiceStub, rs: RootService, stmt, params, noWait):
     paramsObj = []
     for key, value in params.items():
-        paramsObj.append(schema_pb2.NamedParam(name=key, value=py_to_sqlvalue(value)))
+        paramsObj.append(schema_pb2.NamedParam(
+            name=key, value=py_to_sqlvalue(value)))
 
     request = schema_pb2.SQLExecRequest(
         sql=stmt,

--- a/immudb/handler/sqlexec.py
+++ b/immudb/handler/sqlexec.py
@@ -1,0 +1,33 @@
+# Copyright 2021 CodeNotary, Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#       http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+
+from immudb.grpc import schema_pb2
+from immudb.grpc import schema_pb2_grpc
+from immudb.rootService import RootService
+from immudb import datatypes
+from immudb.typeconv import py_to_sqlvalue
+
+
+def call(service: schema_pb2_grpc.ImmuServiceStub, rs: RootService, stmt, params, noWait):
+    paramsObj = []
+    for key, value in params.items():
+        paramsObj.append(schema_pb2.NamedParam(name=key, value=py_to_sqlvalue(value)))
+
+    request = schema_pb2.SQLExecRequest(
+        sql=stmt,
+        params=paramsObj,
+        noWait=noWait)
+
+    result = service.SQLExec(request)
+    return result

--- a/immudb/handler/sqlquery.py
+++ b/immudb/handler/sqlquery.py
@@ -10,12 +10,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dataclasses import dataclass
-
 from immudb.grpc import schema_pb2
 from immudb.grpc import schema_pb2_grpc
 from immudb.rootService import RootService
-from immudb import datatypes
 from immudb.typeconv import py_to_sqlvalue
 from immudb.typeconv import sqlvalue_to_py
 
@@ -23,7 +20,8 @@ from immudb.typeconv import sqlvalue_to_py
 def call(service: schema_pb2_grpc.ImmuServiceStub, rs: RootService, query, params):
     paramsObj = []
     for key, value in params.items():
-        paramsObj.append(schema_pb2.NamedParam(name=key, value=py_to_sqlvalue(value)))
+        paramsObj.append(schema_pb2.NamedParam(
+            name=key, value=py_to_sqlvalue(value)))
 
     request = schema_pb2.SQLQueryRequest(
         sql=query,

--- a/immudb/handler/sqlquery.py
+++ b/immudb/handler/sqlquery.py
@@ -1,0 +1,36 @@
+# Copyright 2021 CodeNotary, Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#       http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+
+from immudb.grpc import schema_pb2
+from immudb.grpc import schema_pb2_grpc
+from immudb.rootService import RootService
+from immudb import datatypes
+from immudb.typeconv import py_to_sqlvalue
+from immudb.typeconv import sqlvalue_to_py
+
+
+def call(service: schema_pb2_grpc.ImmuServiceStub, rs: RootService, query, params):
+    paramsObj = []
+    for key, value in params.items():
+        paramsObj.append(schema_pb2.NamedParam(name=key, value=py_to_sqlvalue(value)))
+
+    request = schema_pb2.SQLQueryRequest(
+        sql=query,
+        params=paramsObj)
+
+    resp = service.SQLQuery(request)
+    result = []
+    for row in resp.rows:
+        result.append([sqlvalue_to_py(i) for i in row.values])
+    return result

--- a/immudb/handler/sqlquery.py
+++ b/immudb/handler/sqlquery.py
@@ -30,5 +30,5 @@ def call(service: schema_pb2_grpc.ImmuServiceStub, rs: RootService, query, param
     resp = service.SQLQuery(request)
     result = []
     for row in resp.rows:
-        result.append([sqlvalue_to_py(i) for i in row.values])
+        result.append(tuple([sqlvalue_to_py(i) for i in row.values]))
     return result

--- a/immudb/typeconv.py
+++ b/immudb/typeconv.py
@@ -1,21 +1,24 @@
 from immudb.grpc import schema_pb2
 from pprint import pformat
 
+
 def py_to_sqlvalue(value):
     sqlValue = None
     if value is None:
-        sqlValue=schema_pb2.SQLValue(null=value)
+        sqlValue = schema_pb2.SQLValue(null=value)
     elif isinstance(value, int):
-        sqlValue=schema_pb2.SQLValue(n=value)
+        sqlValue = schema_pb2.SQLValue(n=value)
     elif isinstance(value, bool):
-        sqlValue=schema_pb2.SQLValue(b=value)
+        sqlValue = schema_pb2.SQLValue(b=value)
     elif isinstance(value, str):
-        sqlValue=schema_pb2.SQLValue(s=value)
+        sqlValue = schema_pb2.SQLValue(s=value)
     elif isinstance(value, bytearray):
-        sqlValue=schema_pb2.SQLValue(bs=value)
+        sqlValue = schema_pb2.SQLValue(bs=value)
     else:
-        raise TypeError("Type not supported: %s".format(value.__class__.__name__))
+        raise TypeError("Type not supported: %s".format(
+            value.__class__.__name__))
     return sqlValue
+
 
 def sqlvalue_to_py(sqlValue):
     if sqlValue.HasField("n"):

--- a/immudb/typeconv.py
+++ b/immudb/typeconv.py
@@ -1,0 +1,32 @@
+from immudb.grpc import schema_pb2
+from pprint import pformat
+
+def py_to_sqlvalue(value):
+    sqlValue = None
+    if value is None:
+        sqlValue=schema_pb2.SQLValue(null=value)
+    elif isinstance(value, int):
+        sqlValue=schema_pb2.SQLValue(n=value)
+    elif isinstance(value, bool):
+        sqlValue=schema_pb2.SQLValue(b=value)
+    elif isinstance(value, str):
+        sqlValue=schema_pb2.SQLValue(s=value)
+    elif isinstance(value, bytearray):
+        sqlValue=schema_pb2.SQLValue(bs=value)
+    else:
+        raise TypeError("Type not supported: %s".format(value.__class__.__name__))
+    return sqlValue
+
+def sqlvalue_to_py(sqlValue):
+    if sqlValue.HasField("n"):
+        return sqlValue.n
+    elif sqlValue.HasField("b"):
+        return sqlValue.b
+    elif sqlValue.HasField("bs"):
+        return sqlValue.bs
+    elif sqlValue.HasField("s"):
+        return sqlValue.s
+    elif sqlValue.HasField("null"):
+        return None
+    else:
+        raise TypeError("Type not supported: %s", sqlValue.WhichOneof("value"))

--- a/tests/immu/test_sql.py
+++ b/tests/immu/test_sql.py
@@ -1,0 +1,37 @@
+# Copyright 2021 CodeNotary, Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#       http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from immudb.client import ImmudbClient
+import grpc._channel
+
+class TestSql:
+
+    def test_exec_query(self):
+        try:
+            client = ImmudbClient("localhost:3322")
+            client.login("immudb", "immudb")
+        except grpc._channel._InactiveRpcError as e:
+            pytest.skip("Cannot reach immudb server")
+
+        resp = client.sqlExec("create table test (id integer, name varchar, primary key id);")
+        assert(len(resp.ctxs) > 0)
+        assert(len(resp.dtxs) == 0)
+
+        resp = client.sqlExec("insert into test (id, name) values (@id, @name);", {'id': 1, 'name': 'Joe' })
+        assert(len(resp.ctxs) == 0)
+        assert(len(resp.dtxs) > 0)
+
+        result = client.sqlQuery("select id,name from test where id=@id;", {'id': 1})
+        assert(len(result) > 0)
+
+        assert(result == [[1, "Joe"]])

--- a/tests/immu/test_sql.py
+++ b/tests/immu/test_sql.py
@@ -14,6 +14,7 @@ import pytest
 from immudb.client import ImmudbClient
 import grpc._channel
 
+
 class TestSql:
 
     def test_exec_query(self):
@@ -23,18 +24,21 @@ class TestSql:
         except grpc._channel._InactiveRpcError as e:
             pytest.skip("Cannot reach immudb server")
 
-        resp = client.sqlExec("create table test (id integer, name varchar, primary key id);")
+        resp = client.sqlExec(
+            "create table test (id integer, name varchar, primary key id);")
         assert(len(resp.ctxs) > 0)
         assert(len(resp.dtxs) == 0)
 
         resp = client.listTables()
         assert('test' in resp)
 
-        resp = client.sqlExec("insert into test (id, name) values (@id, @name);", {'id': 1, 'name': 'Joe' })
+        resp = client.sqlExec(
+            "insert into test (id, name) values (@id, @name);", {'id': 1, 'name': 'Joe'})
         assert(len(resp.ctxs) == 0)
         assert(len(resp.dtxs) > 0)
 
-        result = client.sqlQuery("select id,name from test where id=@id;", {'id': 1})
+        result = client.sqlQuery(
+            "select id,name from test where id=@id;", {'id': 1})
         assert(len(result) > 0)
 
         assert(result == [(1, "Joe")])

--- a/tests/immu/test_sql.py
+++ b/tests/immu/test_sql.py
@@ -27,6 +27,9 @@ class TestSql:
         assert(len(resp.ctxs) > 0)
         assert(len(resp.dtxs) == 0)
 
+        resp = client.listTables()
+        assert('test' in resp)
+
         resp = client.sqlExec("insert into test (id, name) values (@id, @name);", {'id': 1, 'name': 'Joe' })
         assert(len(resp.ctxs) == 0)
         assert(len(resp.dtxs) > 0)
@@ -34,4 +37,4 @@ class TestSql:
         result = client.sqlQuery("select id,name from test where id=@id;", {'id': 1})
         assert(len(result) > 0)
 
-        assert(result == [[1, "Joe"]])
+        assert(result == [(1, "Joe")])


### PR DESCRIPTION
This PR implements the initial methods `sqlExec`, `sqlQuery` and `listTables`.

Some implementation highlights:

* The query method returns an array of tuples. I see that Cursor in the Db APIs do something similar.
* I did not create a custom objects for the `sqlExec` return. I don't see much the gain. I documented what is returned though.
* While `listTables` also returns a SQL result (a table with rows with a column table and type), I flatten this to an array of strings

