### PR TITLE
updated exceptions as per #25

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ lib/
 .project
 .pydevproject
 .idea
+venv

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ def client_margs(*args, **kwargs):
         else:
             client = ImmudbClient(*args, **kwargs)
             client.login("immudb", "immudb")
-    except grpc._channel._InactiveRpcError as e:
+    except grpc.RpcError as e:
         pytest.skip("Cannot reach immudb server")
         return
     return client

--- a/tests/immu/test_basic.py
+++ b/tests/immu/test_basic.py
@@ -21,7 +21,7 @@ class TestBasicGetSet:
         try:
             a = ImmudbClient("localhost:9999")
             a.login("immudb", "immudb")
-        except grpc._channel._InactiveRpcError:
+        except grpc.RpcError:
             pass
 
     def test_basic(self, client):

--- a/tests/immu/test_execAll.py
+++ b/tests/immu/test_execAll.py
@@ -68,7 +68,7 @@ class TestExecAll:
         try:
             a = ImmudbClient("localhost:3322")
             a.login("immudb", "immudb")
-        except grpc._channel._InactiveRpcError as e:
+        except grpc.RpcError as e:
             pytest.skip("Cannot reach immudb server")
         kvsend = []
         zaddsend = []

--- a/tests/immu/test_statefile.py
+++ b/tests/immu/test_statefile.py
@@ -31,7 +31,7 @@ def test_basic(rootfile):
     try:
         a = ImmudbClient(rs=PersistentRootService(rootfile))
         a.login("immudb", "immudb")
-    except grpc._channel._InactiveRpcError as e:
+    except grpc.RpcError as e:
         pytest.skip("Cannot reach immudb server")
     key = "test_key_{:04d}".format(randint(0, 10000))
     value = "test_value_{:04d}".format(randint(0, 10000))

--- a/tests/immu/test_user_operations.py
+++ b/tests/immu/test_user_operations.py
@@ -32,7 +32,7 @@ class TestUser:
         try:
             resp = client.createUser(user, password, permission, database)
             assert False  # it is not allowed to create a user twice
-        except grpc._channel._InactiveRpcError as e:
+        except grpc.RpcError as e:
             assert e.details() == 'user already exists'
 
         user1 = "test_"+get_random_name(8)
@@ -43,13 +43,13 @@ class TestUser:
         try:
             resp = client.createUser(user1, "12345", permission, database)
             assert False  # it is not allowed to create a trivial password
-        except grpc._channel._InactiveRpcError as e:
+        except grpc.RpcError as e:
             pass
 
         try:
             resp = client.createUser(user1, "12345", permission, database)
             assert False  # it is not allowed to create a trivial password
-        except grpc._channel._InactiveRpcError as e:
+        except grpc.RpcError as e:
             pass
 
         newPassword = "Pw1:"+get_random_string(12)


### PR DESCRIPTION
This PR doesn't affect the actual behavior; This is just a change as suggested by #25 which leaves me to think the actual exception should be dissected after the catch, by either an if statement (generic error for specific rpc status) or an error handler 