### PR TITLE
Added sql describe statement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,4 +29,4 @@ jobs:
         run : |
           pip install autopep8
           export PATH="$HOME/.local/bin":$PATH
-          autopep8 --exit-code --diff --recursive .
+          autopep8 --exit-code --diff --recursive ./immudb --exclude="grpc"

--- a/immudb/client.py
+++ b/immudb/client.py
@@ -16,7 +16,7 @@ from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 from immudb import header_manipulator_client_interceptor
 from immudb.handler import (batchGet, batchSet, changePassword, changePermission, createUser,
                             currentRoot, databaseCreate, databaseList, databaseUse,
-                            get, listUsers, verifiedGet, verifiedSet, setValue, history,
+                            get, listUsers, sqldescribe, verifiedGet, verifiedSet, setValue, history,
                             scan, reference, verifiedreference, zadd, verifiedzadd,
                             zscan, healthcheck, txbyid, verifiedtxbyid, sqlexec, sqlquery,
                             listtables, execAll)
@@ -269,3 +269,6 @@ class ImmudbClient:
 
     def compactIndex(self):
         self.__stub.CompactIndex(google_dot_protobuf_dot_empty__pb2.Empty())
+
+    def describeTable(self, table):
+        return sqldescribe.call(self.__stub, self.__rs, table)

--- a/immudb/datatypes.py
+++ b/immudb/datatypes.py
@@ -82,3 +82,13 @@ class ReferenceRequest():
         self.atTx = atTx
         self.boundRef = atTx > 0
         self.noWait = noWait
+
+
+@dataclass
+class ColumnDescription:
+    name: str
+    type: str
+    nullable: bool
+    index: str
+    autoincrement: bool
+    unique: bool

--- a/immudb/handler/sqldescribe.py
+++ b/immudb/handler/sqldescribe.py
@@ -16,23 +16,30 @@ from immudb.typeconv import sqlvalue_to_py
 from immudb.grpc import schema_pb2
 from immudb.grpc import schema_pb2_grpc
 from immudb.rootService import RootService
-from google.protobuf.empty_pb2 import Empty
 
 
 @dataclass
-class SQLQueryResponse:
-    cols: [schema_pb2.Column]
-    rows: [schema_pb2.Row]
-    values: [tuple]
+class ColumnDescription:
+    name: str
+    type: str
+    nullable: bool
+    index: str
+    autoincrement: bool
+    unique: bool
 
 
 def call(service: schema_pb2_grpc.ImmuServiceStub, rs: RootService, table):
     res = service.DescribeTable(schema_pb2.Table(tableName=table.encode()))
     result = []
     for row in res.rows:
-        result.append(tuple([sqlvalue_to_py(i) for i in row.values]))
-    response = SQLQueryResponse(
-        cols=res.columns, rows=res.rows, values=result
-    )
-    return response
-
+        result.append(
+            ColumnDescription(
+                name=sqlvalue_to_py(row.values[0]),
+                type=sqlvalue_to_py(row.values[1]),
+                nullable=sqlvalue_to_py(row.values[2]),
+                index=sqlvalue_to_py(row.values[3]),
+                autoincrement=sqlvalue_to_py(row.values[4]),
+                unique=sqlvalue_to_py(row.values[5]),
+            )
+        )
+    return result

--- a/immudb/handler/sqldescribe.py
+++ b/immudb/handler/sqldescribe.py
@@ -1,0 +1,27 @@
+# Copyright 2021 CodeNotary, Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#       http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+from immudb.typeconv import sqlvalue_to_py
+
+from immudb.grpc import schema_pb2
+from immudb.grpc import schema_pb2_grpc
+from immudb.rootService import RootService
+from google.protobuf.empty_pb2 import Empty
+
+
+def call(service: schema_pb2_grpc.ImmuServiceStub, rs: RootService, table):
+    res = service.DescribeTable(schema_pb2.Table(tableName=table.encode()))
+    result = []
+    for row in res.rows:
+        result.append(tuple([sqlvalue_to_py(i) for i in row.values]))
+    return result

--- a/immudb/handler/sqldescribe.py
+++ b/immudb/handler/sqldescribe.py
@@ -19,9 +19,20 @@ from immudb.rootService import RootService
 from google.protobuf.empty_pb2 import Empty
 
 
+@dataclass
+class SQLQueryResponse:
+    cols: [schema_pb2.Column]
+    rows: [schema_pb2.Row]
+    values: [tuple]
+
+
 def call(service: schema_pb2_grpc.ImmuServiceStub, rs: RootService, table):
     res = service.DescribeTable(schema_pb2.Table(tableName=table.encode()))
     result = []
     for row in res.rows:
         result.append(tuple([sqlvalue_to_py(i) for i in row.values]))
-    return result
+    response = SQLQueryResponse(
+        cols=res.columns, rows=res.rows, values=result
+    )
+    return response
+

--- a/immudb/handler/sqldescribe.py
+++ b/immudb/handler/sqldescribe.py
@@ -11,21 +11,11 @@
 # limitations under the License.
 
 from dataclasses import dataclass
+from immudb.datatypes import ColumnDescription
 from immudb.typeconv import sqlvalue_to_py
-
 from immudb.grpc import schema_pb2
 from immudb.grpc import schema_pb2_grpc
 from immudb.rootService import RootService
-
-
-@dataclass
-class ColumnDescription:
-    name: str
-    type: str
-    nullable: bool
-    index: str
-    autoincrement: bool
-    unique: bool
 
 
 def call(service: schema_pb2_grpc.ImmuServiceStub, rs: RootService, table):

--- a/immudb/handler/verifiedSet.py
+++ b/immudb/handler/verifiedSet.py
@@ -11,6 +11,7 @@
 # limitations under the License.
 
 from time import time
+from immudb.exceptions import VerificationException
 
 from immudb.grpc import schema_pb2
 from immudb.grpc import schema_pb2_grpc

--- a/tests/immu/test_sql.py
+++ b/tests/immu/test_sql.py
@@ -62,5 +62,5 @@ class TestSql:
         tbname = "test{:04d}".format(randint(0, 10000))
         client.sqlExec(f"CREATE TABLE {tbname} (id INTEGER, name VARCHAR[100], PRIMARY KEY id)")
         response = client.describeTable(tbname)
-        assert response == [('id', 'INTEGER', True, 'PRIMARY KEY', False, True), ('name', 'VARCHAR[100]', True, 'NO', False, False)]
+        assert response.values == [('id', 'INTEGER', True, 'PRIMARY KEY', False, True), ('name', 'VARCHAR[100]', True, 'NO', False, False)]
 

--- a/tests/immu/test_sql.py
+++ b/tests/immu/test_sql.py
@@ -12,6 +12,7 @@
 
 import pytest
 from immudb.client import ImmudbClient
+from immudb.handler.sqldescribe import ColumnDescription
 from immudb.typeconv import py_to_sqlvalue, sqlvalue_to_py
 
 import grpc._channel
@@ -62,5 +63,5 @@ class TestSql:
         tbname = "test{:04d}".format(randint(0, 10000))
         client.sqlExec(f"CREATE TABLE {tbname} (id INTEGER, name VARCHAR[100], PRIMARY KEY id)")
         response = client.describeTable(tbname)
-        assert response.values == [('id', 'INTEGER', True, 'PRIMARY KEY', False, True), ('name', 'VARCHAR[100]', True, 'NO', False, False)]
+        assert response == [ColumnDescription(name='id', type='INTEGER', nullable=True, index='PRIMARY KEY', autoincrement=False, unique=True), ColumnDescription(name='name', type='VARCHAR[100]', nullable=True, index='NO', autoincrement=False, unique=False)]
 

--- a/tests/immu/test_sql.py
+++ b/tests/immu/test_sql.py
@@ -57,3 +57,10 @@ class TestSql:
         assert(len(result) > 0)
 
         assert(result == [(1, "Joe")])
+        
+    def test_describe(self, client):
+        tbname = "test{:04d}".format(randint(0, 10000))
+        client.sqlExec(f"CREATE TABLE {tbname} (id INTEGER, name VARCHAR[100], PRIMARY KEY id)")
+        response = client.describeTable(tbname)
+        assert response == [('id', 'INTEGER', True, 'PRIMARY KEY', False, True), ('name', 'VARCHAR[100]', True, 'NO', False, False)]
+


### PR DESCRIPTION
I wanted to add the describe statement, it looks like it's meant to be handled as a simple SQL Result and this works just fine, but the response is just:
 ```[('id', 'INTEGER', True, 'PRIMARY KEY', False, True), ('name', 'VARCHAR[100]', True, 'NO', False, False)]```. 

Which is manageable as long as you know what each value is referring to but can be confusing otherwise

So that begs the question: Should this be a dict instead?
i.e. 

```
{ 'column': 'id', 'type': 'INTEGER', 'nullable': True, 'index': 'PRIMARY KEY', 'auto_increment': False, 'unique': True }
``` 

Or should a hint or additional value be returned?

