### PR TITLE
[CICD] Notarize immudb-py

### DIFF
--- a/.github/workflows/notarize-immudb-py.yaml
+++ b/.github/workflows/notarize-immudb-py.yaml
@@ -1,17 +1,16 @@
 name: Notarize immudb-py
 
 on:
-  pull_request:
+  push:
     branches:
-      - main
+      - master
       - develop
-    types:
-      - closed
 
 jobs:
   notarize-repository:
     name: Notarize immudb-py repository with cas and vcn
-    uses: codenotary/notarize-with-cas-and-vcn/.github/workflows/notarize-with-cas-and-vcn.yml@main
+    runs-on: [self-hosted, linux]
+    uses: codenotary/notarize-with-cas-and-vcn/.github/workflows/notarize-with-cas-and-vcn.yml@862cb3fbee3fbce20bf0e2fae97ac201c730fe23
     secrets:
       cas-api-key: ${{ secrets.CAS_API_KEY_ATTEST }}
       vcn-api-key: ${{ secrets.CICD_LEDGER1_ACTION_KEY }}

--- a/.github/workflows/notarize-immudb-py.yaml
+++ b/.github/workflows/notarize-immudb-py.yaml
@@ -9,8 +9,7 @@ on:
 jobs:
   notarize-repository:
     name: Notarize immudb-py repository with cas and vcn
-    runs-on: [self-hosted, linux]
-    uses: codenotary/notarize-with-cas-and-vcn/.github/workflows/notarize-with-cas-and-vcn.yml@862cb3fbee3fbce20bf0e2fae97ac201c730fe23
+    uses: codenotary/notarize-with-cas-and-vcn/.github/workflows/notarize-with-cas-and-vcn.yml@8808d22b40dbd0257dfb456c1ab5505d1020cc54
     secrets:
       cas-api-key: ${{ secrets.CAS_API_KEY_ATTEST }}
       vcn-api-key: ${{ secrets.CICD_LEDGER1_ACTION_KEY }}


### PR DESCRIPTION
- Pin reusable workflow call to commit sha for greater security and compatibility
- Remove runs-on directive as it cannot be on calling workflow
- Change trigger to run whenever there is a push to master and develop
- Remove merged condition as it now runs on push