### PR TITLE
fix: extract and verify LinearAdvanceProof in DualProof

### DIFF
--- a/immudb/embedded/store/immustore.py
+++ b/immudb/embedded/store/immustore.py
@@ -24,6 +24,7 @@ class DualProof(printable):
         self.targetBlTxAlh = None
         self.lastInclusionProof = None
         self.linearProof = store.LinearProof()
+        self.linearAdvanceProof = None
 
 
 class LinearProof(printable):
@@ -31,3 +32,9 @@ class LinearProof(printable):
         self.sourceTxID = None
         self.targetTxID = None
         self.terms = None
+
+
+class LinearAdvanceProof(printable):
+    def __init__(self):
+        self.linearProofTerms = None
+        self.inclusionProofs = None

--- a/immudb/embedded/store/verification.py
+++ b/immudb/embedded/store/verification.py
@@ -56,6 +56,48 @@ def VerifyLinearProof(proof, sourceTxID: int, targetTxID: int, sourceAlh: bytes,
     return targetAlh == calculatedAlh
 
 
+def advanceLinearHash(alh: bytes, txID: int, term: bytes) -> bytes:
+    # hash(txID || prevAlh || innerHash) — matches advanceLinearHash in
+    # embedded/store/verification.go.
+    return hashlib.sha256(struct.pack(">Q", txID) + alh + term).digest()
+
+
+def VerifyLinearAdvanceProof(proof, startTxID: int, endTxID: int,
+                             endAlh: bytes, treeRoot: bytes,
+                             treeSize: int) -> bool:
+    """Verify the linear chain on the slice [startTxID..endTxID] is consistent
+    with `treeRoot` (a Merkle root of size `treeSize`) and ends at `endAlh`.
+
+    Mirrors VerifyLinearAdvanceProof in embedded/store/verification.go: each
+    intermediate Alh on the chain must be included in the new Merkle Tree, and
+    the final advance must reach `endAlh`. Returns True when no advance proof
+    is needed (gap of <=1).
+    """
+    if endTxID < startTxID:
+        return False
+    # No advance proof required for adjacent / equal txIDs.
+    if endTxID <= startTxID + 1:
+        return True
+    if (proof is None
+            or proof.linearProofTerms is None
+            or proof.inclusionProofs is None
+            or len(proof.linearProofTerms) != endTxID - startTxID
+            or len(proof.inclusionProofs) != endTxID - startTxID - 1):
+        return False
+    calculatedAlh = proof.linearProofTerms[0]  # alh at startTx+1
+    for txID in range(startTxID + 1, endTxID):
+        if not ahtree.VerifyInclusion(
+                proof.inclusionProofs[txID - startTxID - 1],
+                txID,
+                treeSize,
+                leafFor(calculatedAlh),
+                treeRoot):
+            return False
+        calculatedAlh = advanceLinearHash(
+            calculatedAlh, txID + 1, proof.linearProofTerms[txID - startTxID])
+    return calculatedAlh == endAlh
+
+
 def VerifyDualProof(proof, sourceTxID, targetTxID, sourceAlh, targetAlh):
     if (proof == None or
         proof.sourceTxHeader == None or
@@ -90,12 +132,32 @@ def VerifyDualProof(proof, sourceTxID, targetTxID, sourceAlh, targetAlh):
             proof.targetTxHeader.blRoot) == False:
         return False
     if sourceTxID < proof.targetTxHeader.blTxID:
-        ret = VerifyLinearProof(
-            proof.linearProof, proof.targetTxHeader.blTxID, targetTxID, proof.targetBlTxAlh, targetAlh)
-    else:
-        ret = VerifyLinearProof(
-            proof.linearProof, sourceTxID, targetTxID, sourceAlh, targetAlh)
-    return ret
+        if not VerifyLinearProof(
+                proof.linearProof, proof.targetTxHeader.blTxID,
+                targetTxID, proof.targetBlTxAlh, targetAlh):
+            return False
+        # The slice from sourceTxID..BlTxID is already covered by InclusionProof
+        # above; LinearAdvanceProof seals the linear chain consistency for that
+        # gap inside the new Merkle Tree.
+        return VerifyLinearAdvanceProof(
+            proof.linearAdvanceProof,
+            proof.sourceTxHeader.blTxID,
+            sourceTxID,
+            sourceAlh,
+            proof.targetTxHeader.blRoot,
+            proof.targetTxHeader.blTxID,
+        )
+    if not VerifyLinearProof(
+            proof.linearProof, sourceTxID, targetTxID, sourceAlh, targetAlh):
+        return False
+    return VerifyLinearAdvanceProof(
+        proof.linearAdvanceProof,
+        proof.sourceTxHeader.blTxID,
+        proof.targetTxHeader.blTxID,
+        proof.targetBlTxAlh,
+        proof.targetTxHeader.blRoot,
+        proof.targetTxHeader.blTxID,
+    )
 
 
 def EntrySpecDigestFor(version: int):

--- a/immudb/schema/database_protoconv.py
+++ b/immudb/schema/database_protoconv.py
@@ -87,7 +87,24 @@ def DualProofFromProto(dproof: grpc_DualProof) -> store.DualProof:
     dp.targetBlTxAlh = DigestFromProto(dproof.targetBlTxAlh)
     dp.lastInclusionProof = DigestsFromProto(dproof.lastInclusionProof)
     dp.linearProof = LinearProofFromProto(dproof.linearProof)
+    # Note: the proto field uses upper-camel `LinearAdvanceProof`. The server
+    # always populates this for >=v1.2.0 dual proofs; an empty (default)
+    # message means "no advance proof needed for this gap".
+    dp.linearAdvanceProof = LinearAdvanceProofFromProto(dproof.LinearAdvanceProof)
     return dp
+
+
+def LinearAdvanceProofFromProto(p) -> store.LinearAdvanceProof:
+    if p is None:
+        return None
+    lap = store.LinearAdvanceProof()
+    lap.linearProofTerms = DigestsFromProto(p.linearProofTerms)
+    # Each entry on the wire is a full InclusionProof message but the server
+    # only populates the `terms` field for these (see Go's
+    # LinearAdvanceProofToProto). Flatten to a list[list[bytes]] matching
+    # what ahtree.VerifyInclusion expects.
+    lap.inclusionProofs = [DigestsFromProto(ip.terms) for ip in p.inclusionProofs]
+    return lap
 
 
 def TxHeaderFromProto(hdr: grpc_TxHeader) -> store.TxHeader:

--- a/tests/immu/test_offline.py
+++ b/tests/immu/test_offline.py
@@ -253,3 +253,37 @@ def test_KVMetadataFromProto():
 
 def test_TxMetadataFromProto():
     assert schema.TxMetadataFromProto(None) == None
+
+
+def test_VerifyLinearAdvanceProof_no_gap_returns_true():
+    # When endTxID <= startTxID+1 the server omits the advance proof and
+    # the verifier must accept that as the no-op case (matches Go).
+    assert store.VerifyLinearAdvanceProof(None, 5, 5, b'', b'', 5)
+    assert store.VerifyLinearAdvanceProof(None, 5, 6, b'', b'', 6)
+
+
+def test_VerifyLinearAdvanceProof_inverted_range_rejected():
+    assert not store.VerifyLinearAdvanceProof(None, 10, 5, b'', b'', 10)
+
+
+def test_VerifyLinearAdvanceProof_required_but_missing_rejected():
+    # A real gap (endTxID > startTxID+1) requires a non-nil advance proof.
+    assert not store.VerifyLinearAdvanceProof(None, 1, 5, b'', b'', 5)
+
+
+def test_VerifyLinearAdvanceProof_wrong_term_count_rejected():
+    proof = store.LinearAdvanceProof()
+    proof.linearProofTerms = [b'\x00' * 32]  # 1 term, but gap=4 needs 4
+    proof.inclusionProofs = []
+    assert not store.VerifyLinearAdvanceProof(proof, 1, 5, b'', b'', 5)
+
+
+def test_LinearAdvanceProofFromProto_default_empty_message():
+    # An unpopulated LinearAdvanceProof field on the wire (older server, or
+    # proof with no real gap) must round-trip to an empty-but-non-None object
+    # so VerifyLinearAdvanceProof's "no gap" short-circuit applies.
+    msg = schema_pb2.LinearAdvanceProof()  # proto default
+    lap = schema.LinearAdvanceProofFromProto(msg)
+    assert lap is not None
+    assert lap.linearProofTerms == []
+    assert lap.inclusionProofs == []


### PR DESCRIPTION
## Summary

The Go server's `VerifyDualProof` always validates `LinearAdvanceProof` alongside `LinearProof` (see [`embedded/store/verification.go:200-208` and `:222-230`](https://github.com/codenotary/immudb/blob/master/embedded/store/verification.go)), but the Python client never extracted the field from the gRPC `DualProof` and never called the matching verifier.

For most traffic the gap `LinearAdvanceProof` guards is ≤1 tx so the omission was silent — but a Python client could accept proofs the Go reference would reject when ingestion produces a multi-tx gap between the source's binary log tx and the source/target boundary. That's a soundness gap.

## What changed

- Add a `LinearAdvanceProof` dataclass in `immudb/embedded/store/immustore.py` and a `linearAdvanceProof` field on `DualProof`.
- `LinearAdvanceProofFromProto` pulls `dproof.LinearAdvanceProof` (the proto field is upper-camel) and flattens each per-tx `InclusionProof` to a `list[bytes]` matching `ahtree.VerifyInclusion`'s input shape.
- Port `advanceLinearHash` and `VerifyLinearAdvanceProof` from the Go reference and wire them into `VerifyDualProof`'s two proof branches, preserving Go's parameter ordering exactly.
- 5 new offline regression tests in `tests/immu/test_offline.py`: gap-of-zero / gap-of-one short-circuits, inverted range rejected, required-but-missing rejected, mismatched term count rejected, proto-default empty message round-trips to a non-None object so the no-gap fast path applies.

Existing `test_simulated_set{1,2}` fixtures still pass — the proofs they encode have no real linear gap.

## Relation to issue #2054

Found while investigating [codenotary/immudb#2054](https://github.com/codenotary/immudb/issues/2054). **This is not a fix for that issue** — I could not reproduce the reported `verifiedSet` `ErrCorruptedData` against either current immudb master or v1.9.6 with the same Python client. The fix here closes a separate, real soundness gap that surfaced during that investigation.

## Test plan
- [x] `pytest tests/immu/test_offline.py` — 21/21 pass (16 existing + 5 new)
- [x] Live smoke against immudb master: `verifiedSet` × 5 followed by manual `DualProofFromProto` + `VerifyDualProof` — `linearAdvanceProof` populated, verification accepts the proof